### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Postmates
 [![Build Status](https://travis-ci.org/O-I/postmates.svg?branch=master)](https://travis-ci.org/O-I/postmates)
 [![Coverage Status](https://img.shields.io/coveralls/O-I/postmates.svg)](https://coveralls.io/r/O-I/postmates?branch=master)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/PostmatesAPI/functions?utm_source=PostmatesGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 Ruby wrapper for the [Postmates API](https://postmates.com/developer/docs).
 


### PR DESCRIPTION
Hey there. I added a link in your README to a tool where you can test out Postmates API calls in your browser before using your SDK to connect to the API. I've added it to these other SDKs (Telegram, Shopify and LinkedIn) and gotten feedback that it was pretty useful. If anything, let me know what you think and if you have any feedback. I'm part of the team that built this tool and we're always looking to make it better!