### PR TITLE
Added Rate Limit error

### DIFF
--- a/lib/faraday/raise_http_exception.rb
+++ b/lib/faraday/raise_http_exception.rb
@@ -14,6 +14,7 @@ module FaradayMiddleware
         when 401 ; raise Postmates::Unauthorized,        msg
         when 403 ; raise Postmates::Forbidden,           msg
         when 404 ; raise Postmates::NotFound,            msg
+        when 429 ; raise Postmates::RateLimit,           msg
         when 500 ; raise Postmates::InternalServerError, msg
         when 503 ; raise Postmates::ServiceUnavailable,  msg
         end

--- a/lib/postmates/error.rb
+++ b/lib/postmates/error.rb
@@ -4,6 +4,7 @@ module Postmates
   class Unauthorized        < Error; end # 401
   class Forbidden           < Error; end # 403
   class NotFound            < Error; end # 404
+  class RateLimit           < Error; end # 429
   class InternalServerError < Error; end # 500
   class ServiceUnavailable  < Error; end # 503
 end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -55,6 +55,23 @@ describe Postmates::Error do
       end
     end
 
+    describe 'rate limit reached' do
+      before do
+        50.times do
+          stub_post(path_to('deliveries'),
+                    params.merge(response_code: 400,
+                                 returns: 'invalid_params.json'))
+        end
+        stub_get(path_to('deliveries'),
+                 response_code: 429, returns: 'rate_limit.json')
+      end
+
+      it 'raises Postmates::RateLimit' do
+        expect { client.list ) }
+          .to raise_error Postmates::RateLimit
+      end
+    end
+
     describe 'when there is a problem processing the request' do
       before do
         stub_get(path_to('deliveries'),

--- a/spec/fixtures/rate_limit.json
+++ b/spec/fixtures/rate_limit.json
@@ -1,0 +1,5 @@
+{
+  "kind": "error",
+  "code": "rate_limit_exceeded",
+  "message": "You are attempting to exceed our rate limit"
+}


### PR DESCRIPTION
Added Rate Limit error state for the Rate Limiting with status code 429.

Sandbox: 50 requests/minute
Production: 1000 requests/minute

See also Postmates documentation on Rate Limiting:
https://postmates.com/developer/docs#requests